### PR TITLE
Create ambiguous build.js and release-ci.js files that add support for Windows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
+build.js
+release-ci.js
 /dist

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+'unsafe-perm = true'  

--- a/build.js
+++ b/build.js
@@ -1,0 +1,26 @@
+const os = require('os');
+const exec = require('child_process').exec;
+const fs = require('fs');
+
+function puts(error, stdout, stderr) {
+    if (stdout || error || stderr) {
+        console.log(stdout, error, stderr);
+    }
+}
+
+console.log('Start build [' + os.type() + ']...');
+
+// Run command depending on the OS
+if (os.type() === 'Linux') {
+    exec('rm -rf ./dist && tsc', puts);
+} else if (os.type() === 'Darwin') {
+    exec('rm -rf ./dist && tsc', puts);
+} else if (os.type() === 'Windows_NT') {
+    if (fs.existsSync('dist')) {
+        exec('rd /s /q dist && tsc', puts);
+    } else {
+        exec('tsc', puts);
+    }
+} else {
+    throw new Error('Unsupported OS found: ' + os.type());
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
-        "build": "rm -rf ./dist && tsc",
+        "build": "node build.js",
         "watch": "yarn run build && npm-watch build",
         "prepublishOnly": "yarn run build",
         "test": "jest",
@@ -15,7 +15,7 @@
         "fixcode": "yarn run pretty",
         "semantic-release": "semantic-release",
         "release": "yarn run semantic-release",
-        "release-ci": "echo 'unsafe-perm = true' > ./.npmrc && yarn run semantic-release && rm -rf ./.npmrc",
+        "release-ci": "node release-ci.js",
         "commit": "git-cz"
     },
     "watch": {
@@ -71,7 +71,7 @@
         "eslint-plugin-node": ">=7.0.0",
         "eslint-plugin-promise": ">=4.0.0",
         "eslint-plugin-standard": ">=4.0.0",
-        "husky": "^1.3.1",
+        "husky": "^6.0.0",
         "jest": "^24.5.0",
         "lint-staged": "^8.1.5",
         "memfs": "^2.15.2",

--- a/release-ci.js
+++ b/release-ci.js
@@ -1,0 +1,31 @@
+const os = require('os');
+const exec = require('child_process').exec;
+const fs = require('fs');
+
+function puts(error, stdout, stderr) {
+    if (stdout || error || stderr) {
+        console.log(stdout, error, stderr);
+    }
+}
+
+console.log('Start build [' + os.type() + ']...');
+
+// Run command depending on the OS
+if (os.type() === 'Linux') {
+    exec(
+        "echo 'unsafe-perm = true' > ./.npmrc && yarn run semantic-release && rm -rf ./.npmrc",
+        puts,
+    );
+} else if (os.type() === 'Darwin') {
+    exec(
+        "echo 'unsafe-perm = true' > ./.npmrc && yarn run semantic-release && rm -rf ./.npmrc",
+        puts,
+    );
+} else if (os.type() === 'Windows_NT') {
+    exec(
+        "echo 'unsafe-perm = true' > npmrc && yarn run semantic-release && del npmrc",
+        puts,
+    );
+} else {
+    throw new Error('Unsupported OS found: ' + os.type());
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,7 +1818,7 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.1, cosmiconfig@^5.0.2, cosmiconfig@^5.0.7:
+cosmiconfig@^5.0.1, cosmiconfig@^5.0.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
   integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
@@ -3270,21 +3270,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
-  integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
-  dependencies:
-    cosmiconfig "^5.0.7"
-    execa "^1.0.0"
-    find-up "^3.0.0"
-    get-stdin "^6.0.0"
-    is-ci "^2.0.0"
-    pkg-dir "^3.0.0"
-    please-upgrade-node "^3.1.1"
-    read-pkg "^4.0.1"
-    run-node "^1.0.0"
-    slash "^2.0.0"
+husky@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -6066,7 +6055,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
+please-upgrade-node@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
   integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
@@ -6368,7 +6357,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^4.0.0, read-pkg@^4.0.1:
+read-pkg@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
   integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
@@ -6677,11 +6666,6 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
-
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Scripts in package.json no longer use the command rm (which did not work on windows and was preventing the module from building). Instead the build & release-ci scripts point to new .js files which determine your OS and then perform the proper, OS-specific, command.